### PR TITLE
Validate receipt ID before lookup

### DIFF
--- a/src/routes/pbi.ts
+++ b/src/routes/pbi.ts
@@ -60,6 +60,7 @@ const VerifyReq = z.object({
     pubKeyPem: z.string().min(1)
   })
 });
+const ReceiptIdParam = z.string().uuid();
 
 pbiRouter.post(
   "/challenge",
@@ -256,12 +257,13 @@ pbiRouter.get(
     const apiKey = req.apiKey!;
     const receiptId = String(req.params.id ?? "").trim();
 
-    if (!receiptId) {
-      res.status(400).json({ error: "invalid_receipt_id" });
+    const parsedReceiptId = ReceiptIdParam.safeParse(receiptId);
+    if (!parsedReceiptId.success) {
+      res.status(400).json({ error: "invalid_receipt_id", issues: parsedReceiptId.error.issues });
       return;
     }
 
-    const receipt = await getReceiptById(apiKey.id, receiptId);
+    const receipt = await getReceiptById(apiKey.id, parsedReceiptId.data);
     if (!receipt) {
       res.status(404).json({ error: "receipt_not_found" });
       return;


### PR DESCRIPTION
### Motivation
- Prevent malformed `receiptId` path params (non-UUID) from reaching `getReceiptById` and causing Postgres UUID parse errors and 500 responses by validating the ID earlier.

### Description
- Add `ReceiptIdParam = z.string().uuid()` and use `ReceiptIdParam.safeParse` in the GET `/receipts/:id` handler to return `400` with validation `issues` on invalid input and pass the parsed id to `getReceiptById` in `src/routes/pbi.ts`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ed354c3ac832eb026a8e529d36406)