### PR TITLE
Enforce read scope on receipts endpoints

### DIFF
--- a/src/routes/pbi.ts
+++ b/src/routes/pbi.ts
@@ -521,6 +521,7 @@ pbiRouter.get(
 
 pbiRouter.get(
   "/receipts/:id",
+  requireScope("pbi.read_receipts"),
   asyncHandler(async (req: AuthedRequest, res: Response) => {
     const apiKey = req.apiKey!;
     const traceId = (req as AuthedRequest & { requestId?: string }).requestId;
@@ -619,6 +620,7 @@ pbiRouter.post(
 
 pbiRouter.get(
   "/receipts",
+  requireScope("pbi.read_receipts"),
   asyncHandler(async (req: AuthedRequest, res: Response) => {
     const apiKey = req.apiKey!;
     const traceId = (req as AuthedRequest & { requestId?: string }).requestId;


### PR DESCRIPTION
### Motivation
- Scoped API keys (e.g. `pbi.verify`) were able to read receipts because the receipts listing and receipt-by-id routes were mounted without a `pbi.read_receipts` guard, so the new scope model needs enforcement on those endpoints.

### Description
- Add `requireScope("pbi.read_receipts")` to the `GET /receipts` and `GET /receipts/:id` handlers in `src/routes/pbi.ts` to ensure only keys with the `pbi.read_receipts` scope can list or fetch receipts.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eef5c0568832e934035b095cc041a)