### PR TITLE
Add plug-and-play receipts SDK and Express guard

### DIFF
--- a/src/sdk/client.ts
+++ b/src/sdk/client.ts
@@ -1,0 +1,206 @@
+import type { CanonicalAction } from "../pbi/canonical.js";
+import { actionHashHex } from "../pbi/canonical.js";
+
+export type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+
+export type PbiClientConfig = {
+  apiKey: string;
+  baseUrl?: string;
+  fetchImpl?: FetchLike;
+  userAgent?: string;
+};
+
+export type ChallengeRequest = {
+  purpose?: string;
+  kind?: string;
+  actionHashHex: string;
+  ttlSeconds?: number;
+};
+
+export type ChallengeResponse = {
+  id: string;
+  challengeB64Url: string;
+  expiresAtIso: string;
+  purpose: string;
+  actionHashHex: string;
+  challenge?: Record<string, unknown>;
+  metering?: Record<string, string>;
+};
+
+export type VerifyRequest = {
+  challengeId: string;
+  assertion: {
+    authenticatorDataB64Url: string;
+    clientDataJSONB64Url: string;
+    signatureB64Url: string;
+    credIdB64Url: string;
+    pubKeyPem: string;
+  };
+};
+
+export type VerifyResponse = {
+  ok: boolean;
+  decision: string;
+  receiptId?: string;
+  receiptHashHex?: string;
+  receipt?: Record<string, unknown>;
+  reason?: string;
+};
+
+export type ReceiptResponse = {
+  receipt: Record<string, unknown>;
+  challenge?: Record<string, unknown> | null;
+};
+
+export type ReceiptListResponse = {
+  receipts: Array<Record<string, unknown>>;
+  nextCursor: string | null;
+};
+
+export type ReceiptVerifyRequest = {
+  receiptId: string;
+  receiptHashHex: string;
+};
+
+export type ReceiptVerifyResponse = {
+  ok: boolean;
+  receipt?: Record<string, unknown>;
+  challenge?: Record<string, unknown> | null;
+  reason?: string;
+};
+
+export type ReceiptExportResponse = Uint8Array;
+
+export type ReceiptListQuery = {
+  limit?: number;
+  cursor?: string;
+  createdAfter?: string;
+  createdBefore?: string;
+  order?: "asc" | "desc";
+  actionHashHex?: string;
+  challengeId?: string;
+  purpose?: string;
+  decision?: "PBI_VERIFIED" | "FAILED" | "EXPIRED" | "REPLAYED";
+};
+
+export type ReceiptIntent = {
+  purpose: CanonicalAction["purpose"];
+  payload: CanonicalAction["payload"];
+  ttlSeconds?: number;
+};
+
+export class PbiReceiptsClient {
+  private apiKey: string;
+  private baseUrl: string;
+  private fetchImpl: FetchLike;
+  private userAgent?: string;
+
+  constructor(config: PbiClientConfig) {
+    if (!config.apiKey) {
+      throw new Error("PbiReceiptsClient requires apiKey");
+    }
+    this.apiKey = config.apiKey;
+    this.baseUrl = (config.baseUrl ?? "https://api.kojib.com").replace(/\/$/, "");
+    this.fetchImpl = config.fetchImpl ?? fetch;
+    this.userAgent = config.userAgent;
+  }
+
+  createActionHash(intent: ReceiptIntent): string {
+    return actionHashHex({ purpose: intent.purpose, payload: intent.payload });
+  }
+
+  async createReceiptIntent(intent: ReceiptIntent): Promise<ChallengeResponse> {
+    const actionHashHex = this.createActionHash(intent);
+    return this.createChallenge({
+      purpose: intent.purpose,
+      actionHashHex,
+      ttlSeconds: intent.ttlSeconds
+    });
+  }
+
+  async createChallenge(body: ChallengeRequest): Promise<ChallengeResponse> {
+    return this.requestJson("/v1/pbi/challenge", {
+      method: "POST",
+      body: JSON.stringify(body)
+    });
+  }
+
+  async verifyChallenge(body: VerifyRequest): Promise<VerifyResponse> {
+    return this.requestJson("/v1/pbi/verify", {
+      method: "POST",
+      body: JSON.stringify(body)
+    });
+  }
+
+  async getReceipt(receiptId: string): Promise<ReceiptResponse> {
+    return this.requestJson(`/v1/pbi/receipts/${encodeURIComponent(receiptId)}`);
+  }
+
+  async getReceiptForChallenge(challengeId: string): Promise<ReceiptResponse> {
+    return this.requestJson(`/v1/pbi/challenges/${encodeURIComponent(challengeId)}/receipt`);
+  }
+
+  async listReceipts(query: ReceiptListQuery = {}): Promise<ReceiptListResponse> {
+    const qs = toQueryString(query);
+    return this.requestJson(`/v1/pbi/receipts${qs}`);
+  }
+
+  async verifyReceipt(body: ReceiptVerifyRequest): Promise<ReceiptVerifyResponse> {
+    return this.requestJson("/v1/pbi/receipts/verify", {
+      method: "POST",
+      body: JSON.stringify(body)
+    });
+  }
+
+  async exportReceipts(query: ReceiptListQuery & { limit: number }): Promise<ReceiptExportResponse> {
+    const qs = toQueryString(query);
+    return this.requestBinary(`/v1/pbi/receipts/export${qs}`);
+  }
+
+  private async requestJson<T>(path: string, init: RequestInit = {}): Promise<T> {
+    const headers = new Headers(init.headers ?? {});
+    headers.set("Authorization", `Bearer ${this.apiKey}`);
+    headers.set("Accept", "application/json");
+    if (this.userAgent) headers.set("User-Agent", this.userAgent);
+    if (init.body) headers.set("Content-Type", "application/json");
+
+    const resp = await this.fetchImpl(`${this.baseUrl}${path}`, { ...init, headers });
+    const text = await resp.text();
+    const payload = text ? (JSON.parse(text) as T) : ({} as T);
+
+    if (!resp.ok) {
+      const error = new Error(`PBI request failed (${resp.status})`);
+      Object.assign(error, { status: resp.status, payload });
+      throw error;
+    }
+
+    return payload;
+  }
+
+  private async requestBinary(path: string, init: RequestInit = {}): Promise<Uint8Array> {
+    const headers = new Headers(init.headers ?? {});
+    headers.set("Authorization", `Bearer ${this.apiKey}`);
+    if (this.userAgent) headers.set("User-Agent", this.userAgent);
+
+    const resp = await this.fetchImpl(`${this.baseUrl}${path}`, { ...init, headers });
+    const buffer = new Uint8Array(await resp.arrayBuffer());
+
+    if (!resp.ok) {
+      const error = new Error(`PBI request failed (${resp.status})`);
+      Object.assign(error, { status: resp.status, payload: buffer });
+      throw error;
+    }
+
+    return buffer;
+  }
+}
+
+function toQueryString(query: Record<string, string | number | undefined>): string {
+  const entries = Object.entries(query).filter(([, value]) => value !== undefined);
+  if (entries.length === 0) return "";
+  const search = new URLSearchParams();
+  for (const [key, value] of entries) {
+    search.set(key, String(value));
+  }
+  return `?${search.toString()}`;
+}

--- a/src/sdk/express.ts
+++ b/src/sdk/express.ts
@@ -1,0 +1,65 @@
+import type { NextFunction, Request, RequestHandler, Response } from "express";
+import type { ReceiptVerifyResponse } from "./client.js";
+import { PbiReceiptsClient } from "./client.js";
+
+export type ReceiptGuardOptions = {
+  receiptIdHeader?: string;
+  receiptHashHeader?: string;
+  onFailure?: (res: Response, result: ReceiptGuardFailure) => void;
+};
+
+export type ReceiptGuardFailure = {
+  error: "missing_receipt" | "invalid_receipt" | "verification_failed";
+  status: number;
+  result?: ReceiptVerifyResponse;
+};
+
+export type ReceiptGuardRequest = Request & {
+  pbiReceipt?: Record<string, unknown>;
+};
+
+export function createReceiptGuard(
+  client: PbiReceiptsClient,
+  options: ReceiptGuardOptions = {}
+): RequestHandler {
+  const receiptIdHeader = options.receiptIdHeader ?? "x-pbi-receipt-id";
+  const receiptHashHeader = options.receiptHashHeader ?? "x-pbi-receipt-hash";
+
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const receiptId = req.header(receiptIdHeader) ?? "";
+    const receiptHashHex = req.header(receiptHashHeader) ?? "";
+
+    if (!receiptId || !receiptHashHex) {
+      const failure: ReceiptGuardFailure = { error: "missing_receipt", status: 400 };
+      if (options.onFailure) {
+        options.onFailure(res, failure);
+      } else {
+        res.status(failure.status).json({ error: failure.error });
+      }
+      return;
+    }
+
+    try {
+      const result = await client.verifyReceipt({ receiptId, receiptHashHex });
+      if (!result.ok) {
+        const failure: ReceiptGuardFailure = { error: "invalid_receipt", status: 403, result };
+        if (options.onFailure) {
+          options.onFailure(res, failure);
+        } else {
+          res.status(failure.status).json({ error: failure.error, reason: result.reason });
+        }
+        return;
+      }
+
+      (req as ReceiptGuardRequest).pbiReceipt = result.receipt;
+      next();
+    } catch (err) {
+      const failure: ReceiptGuardFailure = { error: "verification_failed", status: 502 };
+      if (options.onFailure) {
+        options.onFailure(res, failure);
+      } else {
+        res.status(failure.status).json({ error: failure.error });
+      }
+    }
+  };
+}

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -1,0 +1,18 @@
+export { PbiReceiptsClient } from "./client.js";
+export type {
+  ChallengeRequest,
+  ChallengeResponse,
+  FetchLike,
+  PbiClientConfig,
+  ReceiptExportResponse,
+  ReceiptIntent,
+  ReceiptListQuery,
+  ReceiptListResponse,
+  ReceiptResponse,
+  ReceiptVerifyRequest,
+  ReceiptVerifyResponse,
+  VerifyRequest,
+  VerifyResponse
+} from "./client.js";
+export { createReceiptGuard } from "./express.js";
+export type { ReceiptGuardFailure, ReceiptGuardOptions, ReceiptGuardRequest } from "./express.js";


### PR DESCRIPTION
### Motivation
- Provide a lightweight, developer-friendly SDK (Stripe-checkout-style) to make creating receipt intents and verifying receipts trivial for integrators.
- Offer a drop-in Express middleware to simplify server-side receipt verification and protect fulfillment endpoints.

### Description
- Added a TypeScript SDK at `src/sdk/client.ts` implementing `PbiReceiptsClient` with methods `createReceiptIntent`, `createChallenge`, `verifyChallenge`, `getReceipt`, `getReceiptForChallenge`, `listReceipts`, `verifyReceipt`, and `exportReceipts` (export now returns binary `Uint8Array`).
- Added an Express middleware helper `createReceiptGuard` in `src/sdk/express.ts` to verify `x-pbi-receipt-id` / `x-pbi-receipt-hash` and populate `req.pbiReceipt` on success.
- Exported SDK symbols from `src/sdk/index.ts` and updated `README.md` with usage examples showing `PbiReceiptsClient` and `createReceiptGuard` integration patterns.
- Implemented JSON and binary request helpers (`requestJson` / `requestBinary`) and a small `createActionHash` helper that reuses existing `actionHashHex` logic from `src/pbi/canonical.js`.

### Testing
- No automated tests were executed for this change (no CI/tests run as part of this patch).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f34afb8e0832eb08e7fcc79cd7106)